### PR TITLE
Refactor: send message optimize

### DIFF
--- a/kook_adapter/kook_client.py
+++ b/kook_adapter/kook_client.py
@@ -12,7 +12,7 @@ import websockets
 
 from astrbot import logger
 
-from .kook_types import KookMessageType
+from .kook_types import KookMessageType, KookApiPaths
 
 
 class KookClient:
@@ -43,7 +43,7 @@ class KookClient:
 
     async def get_bot_id(self) -> str:
         """获取机器人账号ID"""
-        url = "https://www.kookapp.cn/api/v3/user/me"
+        url = KookApiPaths.USER_ME
 
         try:
             async with self._http_client.get(url) as resp:
@@ -65,7 +65,7 @@ class KookClient:
 
     async def get_gateway_url(self, resume=False, sn=0, session_id=None):
         """获取网关连接地址"""
-        url = "https://www.kookapp.cn/api/v3/gateway/index"
+        url = KookApiPaths.GATEWAY_INDEX
 
         # 构建连接参数
         params = {}
@@ -303,7 +303,7 @@ class KookClient:
         消息发送接口文档参见: https://developer.kookapp.cn/doc/http/message#%E5%8F%91%E9%80%81%E9%A2%91%E9%81%93%E8%81%8A%E5%A4%A9%E6%B6%88%E6%81%AF
         KMarkdown格式参见: https://developer.kookapp.cn/doc/kmarkdown-desc
         """
-        url = "https://www.kookapp.cn/api/v3/message/create"
+        url = KookApiPaths.CHANNEL_MESSAGE_CREATE
 
         payload = {"target_id": channel_id, "content": content, "type": message_type}
         if reply_message_id:
@@ -355,7 +355,7 @@ class KookClient:
         data = aiohttp.FormData()
         data.add_field("file", bytes_data, filename=filename)
 
-        url = "https://www.kookapp.cn/api/v3/asset/create"
+        url = KookApiPaths.ASSET_CREATE
         try:
             async with self._http_client.post(url, data=data) as resp:
                 if resp.status == 200:

--- a/kook_adapter/kook_types.py
+++ b/kook_adapter/kook_types.py
@@ -7,6 +7,21 @@ from pydantic import BaseModel, ConfigDict
 from pydantic.dataclasses import dataclass
 
 
+class KookApiPaths:
+    """Kook Api 路径"""
+
+    BASE_URL = "https://www.kookapp.cn"
+    API_VERSION_PATH = "/api/v3"
+
+    # 初始化相关
+    USER_ME = f"{BASE_URL}{API_VERSION_PATH}/user/me"
+    GATEWAY_INDEX = f"{BASE_URL}{API_VERSION_PATH}/gateway/index"
+
+    # 消息相关
+    CHANNEL_MESSAGE_CREATE = f"{BASE_URL}{API_VERSION_PATH}/message/create"
+    ASSET_CREATE = f"{BASE_URL}{API_VERSION_PATH}/asset/create"
+
+
 # 定义参见kook事件结构文档: https://developer.kookapp.cn/doc/event/event-introduction
 class KookMessageType(IntEnum):
     TEXT = 1


### PR DESCRIPTION
## Summary by Sourcery

重构 KOOK 客户端的 HTTP 交互，以复用共享的已认证会话，并集中管理 API 端点定义。

增强内容：
- 在 `KookClient` 上引入共享的 `aiohttp ClientSession`，并将其复用于所有 KOOK 的 HTTP 请求，而不是在每次调用时创建新的会话。
- 将 KOOK API 基础 URL 和各端点集中到一个 `KookApiPaths` 辅助类中，用常量替换硬编码的 URL 字符串。
- 确保在 `KookClient` 关闭时正确关闭共享的 HTTP 客户端，并对 WebSocket 使用相关的类型标注进行小幅调整。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor KOOK client HTTP interactions to reuse a shared authenticated session and centralize API endpoint definitions.

Enhancements:
- Introduce a shared aiohttp ClientSession on KookClient and reuse it for all KOOK HTTP requests instead of creating per-call sessions.
- Centralize KOOK API base URL and endpoints into a KookApiPaths helper class and replace hardcoded URL strings with constants.
- Ensure the shared HTTP client is properly closed when the KookClient is shut down and add minor typing adjustments around WebSocket usage.

</details>